### PR TITLE
ignores "VideoDecodeStats" in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+VideoDecodeStats
+
 # CMake
 CMakeCache.txt
 CMakeFiles/


### PR DESCRIPTION
Not sure why that's not in .gitignore already, seems like it should be.