### PR TITLE
Removes the environment variable requirement for procedural material shaders

### DIFF
--- a/libraries/render-utils/src/MeshPartPayload.cpp
+++ b/libraries/render-utils/src/MeshPartPayload.cpp
@@ -23,8 +23,8 @@
 
 #include "RenderPipelines.h"
 
-static const QString ENABLE_MATERIAL_PROCEDURAL_SHADERS_STRING { "HIFI_ENABLE_MATERIAL_PROCEDURAL_SHADERS" };
-static bool ENABLE_MATERIAL_PROCEDURAL_SHADERS = QProcessEnvironment::systemEnvironment().contains(ENABLE_MATERIAL_PROCEDURAL_SHADERS_STRING);
+// static const QString ENABLE_MATERIAL_PROCEDURAL_SHADERS_STRING { "HIFI_ENABLE_MATERIAL_PROCEDURAL_SHADERS" };
+// static bool ENABLE_MATERIAL_PROCEDURAL_SHADERS = QProcessEnvironment::systemEnvironment().contains(ENABLE_MATERIAL_PROCEDURAL_SHADERS_STRING);
 
 bool MeshPartPayload::enableMaterialProceduralShaders = false;
 
@@ -471,7 +471,7 @@ void ModelMeshPartPayload::render(RenderArgs* args) {
 
     if (!_drawMaterials.empty() && _drawMaterials.top().material && _drawMaterials.top().material->isProcedural() &&
             _drawMaterials.top().material->isReady()) {
-        if (!(enableMaterialProceduralShaders && ENABLE_MATERIAL_PROCEDURAL_SHADERS)) {
+        if (!(enableMaterialProceduralShaders)) {
             return;
         }
         auto procedural = std::static_pointer_cast<graphics::ProceduralMaterial>(_drawMaterials.top().material);


### PR DESCRIPTION
With this change, it is no longer necessary to create the HIFI_ENABLE_MATERIAL_PROCEDURAL_SHADERS environment variable. Users only need to have the Developer menu active, and then check the menu option Developer->Render->Enable Procedural Materials

Tested on:
Windows 10 Pro 1909 build 18363.476
CMake 3.16.0
Microsoft Visual Studio Community 2019 Version 16.4.0